### PR TITLE
解决在windows 10系统下报gbk编码错误的问题

### DIFF
--- a/generate_data.py
+++ b/generate_data.py
@@ -7,7 +7,7 @@ import datetime
 
 
 def load_amap_cities():
-    return dict([line.strip().split() for line in open('adcodes').readlines()])
+    return dict([line.strip().split() for line in open('adcodes',encoding='utf8').readlines()])
 
 
 amap_code_to_city = load_amap_cities()


### PR DESCRIPTION
实测代码在windows 10系统Python 3.6下运行报错：
Traceback (most recent call last):
  File ".\generate_data.py", line 13, in <module>
    amap_code_to_city = load_amap_cities()
  File ".\generate_data.py", line 10, in load_amap_cities
    return dict([line.strip().split() for line in open('adcodes').readlines()])
UnicodeDecodeError: 'gbk' codec can't decode byte 0x82 in position 15: illegal multibyte sequence

运行环境：
Windows 10
Python 3.6.0 (v3.6.0:41df79263a11, Dec 23 2016, 08:06:12) [MSC v.1900 64 bit (AMD64)] on win32

修改后：
运行通过